### PR TITLE
add requirements.txt and install_dependecies.sh

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# ubuntu dependencies
+sudo apt update 
+sudo apt install python3-pip libgl1 -y
+
+# install fonts
+sudo apt install ttf-mscorefonts-installer -y
+sudo fc-cache -f
+
+# update pip
+python3 -m pip install --upgrade pip
+# python dependencies
+pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy==1.26.2 # fix for cadquery, numpy==1.23.1 seems OK too
+cadquery
+bpy # blender python API

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-numpy==1.26.2 # fix for cadquery, numpy==1.23.1 seems OK too
+numpy==1.26.4 # fix for cadquery, numpy==1.23.1 seems OK too
 cadquery
 bpy # blender python API


### PR DESCRIPTION
Calling install_dependencies.sh will install everything is required (including python dependencies through pip) for an ubuntu machine, in a single command. This can be used to quickly configure an ubuntu VM, or a codespaces environment.